### PR TITLE
chore: Make fastlane match for ios build verbose

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :ios do
 
   desc 'Build the iOS application.'
   private_lane :build do
-    match(app_identifier: 'co.revelry.nightingale', type: 'appstore', readonly: true)
+    match(type: 'appstore', readonly: true, verbose: true)
     sh "npm install"
     cocoapods(
       podfile: "./ios/Podfile"


### PR DESCRIPTION
I adjusted the params for the build match. Primarily, I wanted to make it verbose so that maybe it'll give us a hint about what's wrong. I also removed the app_identifier, because we don't need it to match against appstore keys (we only need one app store key and it isn't scoped per app).